### PR TITLE
Add integrator and child account support

### DIFF
--- a/src/Api/PrintNode/Util/RequestOptions.php
+++ b/src/Api/PrintNode/Util/RequestOptions.php
@@ -68,6 +68,17 @@ class RequestOptions
                 unset($options['idempotency_key']);
             }
 
+            // Support Integrator Child Accounts
+            // When the caller specifies a `child_account` value, we need to
+            // include the `X-Child-Account` header so the request is scoped to
+            // the given child account (see PrintNode Integrator Accounts docs).
+            if (array_key_exists('child_account', $options)) {
+                $headers['X-Child-Account'] = (string) $options['child_account'];
+
+                // Ensure the option does not bleed through any further
+                unset($options['child_account']);
+            }
+
             if (array_key_exists('api_base', $options)) {
                 $base = $options['api_base'];
                 unset($options['api_base']);


### PR DESCRIPTION
1️⃣ Is this something that is wanted/needed? Did you create an issue / discussion about it first?
Yes, this is needed to support PrintNode Integrator accounts. No prior issue/discussion was created.

2️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.
No, this PR contains a single, focused change to support PrintNode Integrator Child Accounts.

3️⃣ Does it include tests, if possible? (Not a deal-breaker, just a nice-to-have)
No, this PR does not include new tests.

4️⃣ Please include a thorough description of the improvement and reasons why it's useful.
This PR adds support for PrintNode Integrator Child Accounts by introducing a `child_account` request option. When provided, this option automatically adds the `X-Child-Account` header to all API requests, allowing integrators to scope operations to a specific child account. This is crucial for managing multiple client accounts under a single integrator account, as outlined in the PrintNode API documentation ("Account download & management – X-Child-Account").

**Usage:**
You can now specify a `child_account` ID in the request options:
```php
$client->printers->all([], [
    'child_account' => 1234, // Child Account ID
]);
```
This option can also be supplied when instantiating the `PrintNodeClient`.

5️⃣ Thanks for contributing! 🙌

---
<a href="https://cursor.com/background-agent?bcId=bc-9b68b579-9509-4fe8-b8dd-66b2ef495201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b68b579-9509-4fe8-b8dd-66b2ef495201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

