### PR TITLE
Add integrator and child account support

### DIFF
--- a/docs/printnode/account-service.md
+++ b/docs/printnode/account-service.md
@@ -1,0 +1,509 @@
+---
+title: Account Service
+sort: 2
+---
+
+## Introduction
+
+The `AccountService` can be used to manage child accounts under an Integrator account. This service allows you to create, retrieve, modify, and delete child accounts for your customers, as well as manage their credits, tags, and API keys.
+
+**Note:** To use this service, your PrintNode account must be upgraded to an Integrator account. See the [PrintNode documentation](https://www.printnode.com/en/docs/api/curl#account-download-management) for more information.
+
+All methods are callable from the `PrintNodeClient` class.
+
+```php
+$accounts = $client->accounts->all();
+```
+
+See the [API Overview](/docs/laravel-printing/{version}/printnode/api) for more information on interacting with the PrintNode API.
+
+## Reference
+
+### Methods
+
+<hr>
+
+#### all
+
+_Collection<int, Rawilk\Printing\Api\PrintNode\Resources\Account>_
+
+Retrieves all child accounts under your Integrator account.
+
+| param     | type                        | default |
+| --------- | --------------------------- | ------- |
+| `$params` | array\|null                 | null    |
+| `$opts`   | null\|array\|RequestOptions | null    |
+
+**Example:**
+
+```php
+$accounts = $client->accounts->all();
+```
+
+<hr>
+
+#### retrieve
+
+_Rawilk\Printing\Api\PrintNode\Resources\Account_
+
+Retrieve a specific child account by ID.
+
+| param     | type                        | default | description                    |
+| --------- | --------------------------- | ------- | ------------------------------ |
+| `$id`     | int                         |         | the account's ID               |
+| `$params` | array\|null                 | null    | not applicable to this request |
+| `$opts`   | null\|array\|RequestOptions | null    |                                |
+
+**Example:**
+
+```php
+$account = $client->accounts->retrieve(12345);
+```
+
+<hr>
+
+#### create
+
+_Rawilk\Printing\Api\PrintNode\Resources\Account_
+
+Create a new child account under your Integrator account.
+
+| param     | type                        | default | description                        |
+| --------- | --------------------------- | ------- | ---------------------------------- |
+| `$params` | array                       |         | the account creation parameters    |
+| `$opts`   | null\|array\|RequestOptions | null    |                                    |
+
+**Parameters:**
+
+- `Account[firstname]` - First name (deprecated, use "-" and rely on creatorRef)
+- `Account[lastname]` - Last name (deprecated, use "-" and rely on creatorRef)
+- `Account[email]` - Contact email address (required)
+- `Account[password]` - Password (required, min 8 characters)
+- `Account[creatorRef]` - Your unique reference for this account (recommended)
+- `ApiKeys[]` - Array of API key names to create (max 10, max 16 bytes each)
+- `Tags[]` - Object with tag names as keys and tag values as values (max 1024 bytes per value)
+
+**Example:**
+
+```php
+$account = $client->accounts->create([
+    'Account' => [
+        'firstname' => '-',
+        'lastname' => '-',
+        'email' => 'customer@example.com',
+        'password' => 'securepassword',
+        'creatorRef' => 'customer_123',
+    ],
+    'ApiKeys' => ['production', 'development'],
+    'Tags' => [
+        'plan' => 'premium',
+        'region' => 'us-east',
+    ],
+]);
+```
+
+<hr>
+
+#### modify
+
+_Rawilk\Printing\Api\PrintNode\Resources\Account_
+
+Modify an existing child account.
+
+| param     | type                        | default | description                       |
+| --------- | --------------------------- | ------- | --------------------------------- |
+| `$id`     | int                         |         | the account's ID                  |
+| `$params` | array                       |         | the account modification parameters |
+| `$opts`   | null\|array\|RequestOptions | null    |                                   |
+
+**Parameters:**
+
+- `Account[email]` - New email address
+- `Account[password]` - New password (min 8 characters)
+- `Account[creatorRef]` - New creator reference
+- `ApiKeys[]` - Array of API key names to create
+- `Tags[]` - Object with tag names as keys and tag values as values
+
+**Example:**
+
+```php
+$account = $client->accounts->modify(12345, [
+    'Account' => [
+        'email' => 'newemail@example.com',
+    ],
+    'Tags' => [
+        'plan' => 'enterprise',
+    ],
+]);
+```
+
+<hr>
+
+#### delete
+
+_array_
+
+Delete a child account. Method will return an array of affected account IDs.
+
+| param     | type                        | default | description                    |
+| --------- | --------------------------- | ------- | ------------------------------ |
+| `$id`     | int                         |         | the account's ID               |
+| `$params` | array\|null                 | null    | not applicable to this request |
+| `$opts`   | null\|array\|RequestOptions | null    |                                |
+
+**Example:**
+
+```php
+$deletedIds = $client->accounts->delete(12345);
+```
+
+<hr>
+
+#### deleteMany
+
+_array_
+
+Delete multiple child accounts. Method will return an array of affected IDs.
+
+| param     | type                        | default | description                       |
+| --------- | --------------------------- | ------- | --------------------------------- |
+| `$ids`    | array                       |         | the IDs of the accounts to delete |
+| `$params` | array\|null                 | null    |                                   |
+| `$opts`   | null\|array\|RequestOptions | null    |                                   |
+
+**Example:**
+
+```php
+$deletedIds = $client->accounts->deleteMany([12345, 12346]);
+```
+
+<hr>
+
+#### addCredits
+
+_Rawilk\Printing\Api\PrintNode\Resources\Account_
+
+Add credits to a child account.
+
+| param      | type                        | default | description                     |
+| ---------- | --------------------------- | ------- | ------------------------------- |
+| `$id`      | int                         |         | the account's ID                |
+| `$credits` | int                         |         | the number of credits to add    |
+| `$opts`    | null\|array\|RequestOptions | null    |                                 |
+
+**Example:**
+
+```php
+$account = $client->accounts->addCredits(12345, 1000);
+```
+
+<hr>
+
+#### setState
+
+_Rawilk\Printing\Api\PrintNode\Resources\Account_
+
+Set the state of a child account (e.g., suspend or activate).
+
+| param    | type                        | default | description                                |
+| -------- | --------------------------- | ------- | ------------------------------------------ |
+| `$id`    | int                         |         | the account's ID                           |
+| `$state` | string                      |         | the state to set (e.g., 'active', 'suspended') |
+| `$opts`  | null\|array\|RequestOptions | null    |                                            |
+
+**Example:**
+
+```php
+$account = $client->accounts->setState(12345, 'suspended');
+```
+
+<hr>
+
+#### suspend
+
+_Rawilk\Printing\Api\PrintNode\Resources\Account_
+
+Suspend a child account.
+
+| param   | type                        | default | description      |
+| ------- | --------------------------- | ------- | ---------------- |
+| `$id`   | int                         |         | the account's ID |
+| `$opts` | null\|array\|RequestOptions | null    |                  |
+
+**Example:**
+
+```php
+$account = $client->accounts->suspend(12345);
+```
+
+<hr>
+
+#### activate
+
+_Rawilk\Printing\Api\PrintNode\Resources\Account_
+
+Activate a child account.
+
+| param   | type                        | default | description      |
+| ------- | --------------------------- | ------- | ---------------- |
+| `$id`   | int                         |         | the account's ID |
+| `$opts` | null\|array\|RequestOptions | null    |                  |
+
+**Example:**
+
+```php
+$account = $client->accounts->activate(12345);
+```
+
+<hr>
+
+#### deleteTag
+
+_array_
+
+Delete a tag from a child account.
+
+| param      | type                        | default | description                |
+| ---------- | --------------------------- | ------- | -------------------------- |
+| `$id`      | int                         |         | the account's ID           |
+| `$tagName` | string                      |         | the name of the tag to delete |
+| `$opts`    | null\|array\|RequestOptions | null    |                            |
+
+**Example:**
+
+```php
+$client->accounts->deleteTag(12345, 'plan');
+```
+
+<hr>
+
+#### deleteApiKey
+
+_array_
+
+Delete an API key from a child account.
+
+| param     | type                        | default | description            |
+| --------- | --------------------------- | ------- | ---------------------- |
+| `$id`     | int                         |         | the account's ID       |
+| `$apiKey` | string                      |         | the API key to delete  |
+| `$opts`   | null\|array\|RequestOptions | null    |                        |
+
+**Example:**
+
+```php
+$client->accounts->deleteApiKey(12345, 'api_key_abc123');
+```
+
+<hr>
+
+## Account Resource
+
+`Rawilk\Printing\Api\PrintNode\Resources\Account`
+
+An Account represents a child account created under an Integrator account. Child accounts allow you to manage separate PrintNode accounts for your customers while maintaining control through your Integrator account.
+
+### Properties
+
+<hr>
+
+#### id
+
+_int_
+
+The account's ID.
+
+<hr>
+
+#### firstname
+
+_string_
+
+The account holder's first name (deprecated, use creatorRef instead).
+
+<hr>
+
+#### lastname
+
+_string_
+
+The account holder's last name (deprecated, use creatorRef instead).
+
+<hr>
+
+#### email
+
+_string_
+
+The account holder's email address.
+
+<hr>
+
+#### creatorEmail
+
+_string_
+
+The email address of the integrator account that created this account.
+
+<hr>
+
+#### creatorRef
+
+_?string_
+
+The creation reference set when the account was created (your unique identifier).
+
+<hr>
+
+#### createTimestamp
+
+_string_
+
+Time and date the account was created.
+
+<hr>
+
+#### ApiKeys
+
+_array_
+
+A collection of all the API keys set on this account.
+
+<hr>
+
+#### Tags
+
+_array_
+
+A collection of tags set on this account.
+
+<hr>
+
+#### state
+
+_string_
+
+The status of the account (e.g., 'active', 'suspended').
+
+<hr>
+
+#### credits
+
+_?int_
+
+The number of print credits remaining on this account.
+
+<hr>
+
+#### numComputers
+
+_int_
+
+The number of computers active on this account.
+
+<hr>
+
+#### totalPrints
+
+_int_
+
+Total number of prints made on this account.
+
+<hr>
+
+### Methods
+
+<hr>
+
+#### isActive
+
+_bool_
+
+Indicates if the account is considered active.
+
+```php
+if ($account->isActive()) {
+    // Account is active
+}
+```
+
+<hr>
+
+#### isSuspended
+
+_bool_
+
+Indicates if the account is suspended.
+
+```php
+if ($account->isSuspended()) {
+    // Account is suspended
+}
+```
+
+<hr>
+
+#### createdAt
+
+_?CarbonInterface_
+
+A date object representing the time and date the account was created.
+
+```php
+$createdAt = $account->createdAt();
+```
+
+<hr>
+
+## Usage Example
+
+Here's a complete example of managing child accounts:
+
+```php
+use Rawilk\Printing\Api\PrintNode\PrintNodeClient;
+
+// Initialize the client with your Integrator account API key
+$client = new PrintNodeClient(['api_key' => 'your-integrator-api-key']);
+
+// Create a new child account
+$newAccount = $client->accounts->create([
+    'Account' => [
+        'firstname' => '-',
+        'lastname' => '-',
+        'email' => 'customer@example.com',
+        'password' => 'securepassword123',
+        'creatorRef' => 'customer_unique_id',
+    ],
+    'ApiKeys' => ['production'],
+    'Tags' => [
+        'plan' => 'premium',
+        'customer_id' => '12345',
+    ],
+]);
+
+// Add credits to the account
+$client->accounts->addCredits($newAccount->id, 1000);
+
+// List all child accounts
+$accounts = $client->accounts->all();
+
+foreach ($accounts as $account) {
+    echo "Account: {$account->email} - Credits: {$account->credits}\n";
+    
+    if ($account->isActive()) {
+        echo "Status: Active\n";
+    }
+}
+
+// Suspend an account if needed
+$client->accounts->suspend($newAccount->id);
+
+// Activate it again
+$client->accounts->activate($newAccount->id);
+
+// Delete a tag
+$client->accounts->deleteTag($newAccount->id, 'plan');
+
+// Delete the account when no longer needed
+$client->accounts->delete($newAccount->id);
+```

--- a/src/Api/PrintNode/PrintNodeClient.php
+++ b/src/Api/PrintNode/PrintNodeClient.php
@@ -9,6 +9,7 @@ use Rawilk\Printing\Api\PrintNode\Service\ServiceFactory;
 /**
  * Client used to send requests to PrintNode's API.
  *
+ * @property-read \Rawilk\Printing\Api\PrintNode\Service\AccountService $accounts
  * @property-read \Rawilk\Printing\Api\PrintNode\Service\ComputerService $computers
  * @property-read \Rawilk\Printing\Api\PrintNode\Service\PrinterService $printers
  * @property-read \Rawilk\Printing\Api\PrintNode\Service\PrintJobService $printJobs

--- a/src/Api/PrintNode/Resources/Account.php
+++ b/src/Api/PrintNode/Resources/Account.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Api\PrintNode\Resources;
+
+use Carbon\CarbonInterface;
+use Rawilk\Printing\Api\PrintNode\PrintNodeApiResource;
+
+/**
+ * An `Account` represents a child account created under an Integrator account.
+ * Child accounts allow you to manage separate PrintNode accounts for your
+ * customers while maintaining control through your Integrator account.
+ *
+ * @property-read int $id The account's ID
+ * @property-read string $firstname The account holder's first name (deprecated, use creatorRef instead)
+ * @property-read string $lastname The account holder's last name (deprecated, use creatorRef instead)
+ * @property-read string $email The account holder's email address
+ * @property-read string $creatorEmail The email address of the integrator account that created this account
+ * @property-read null|string $creatorRef The creation reference set when the account was created (your unique identifier)
+ * @property-read string $createTimestamp Time and date the account was created
+ * @property-read array $ApiKeys A collection of all the API keys set on this account
+ * @property-read array $Tags A collection of tags set on this account
+ * @property-read string $state The status of the account (e.g. 'active', 'suspended')
+ * @property-read int|null $credits The number of print credits remaining on this account
+ * @property-read int $numComputers The number of computers active on this account
+ * @property-read int $totalPrints Total number of prints made on this account
+ */
+class Account extends PrintNodeApiResource
+{
+    use ApiOperations\Request;
+    use Concerns\HasDateAttributes;
+
+    public static function classUrl(): string
+    {
+        return '/account';
+    }
+
+    public static function resourceUrl(?int $id = null): string
+    {
+        if ($id !== null) {
+            return static::classUrl() . '/' . $id;
+        }
+
+        return static::classUrl();
+    }
+
+    /**
+     * Indicates if the account is considered active.
+     */
+    public function isActive(): bool
+    {
+        return $this->_values['state'] === 'active';
+    }
+
+    /**
+     * Indicates if the account is suspended.
+     */
+    public function isSuspended(): bool
+    {
+        return $this->_values['state'] === 'suspended';
+    }
+
+    /**
+     * Get the account creation timestamp as a Carbon instance.
+     */
+    public function createdAt(): ?CarbonInterface
+    {
+        return $this->parseDate($this->createTimestamp);
+    }
+}

--- a/src/Api/PrintNode/Service/AccountService.php
+++ b/src/Api/PrintNode/Service/AccountService.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Printing\Api\PrintNode\Service;
+
+use Illuminate\Support\Collection;
+use Rawilk\Printing\Api\PrintNode\Resources\Account;
+use Rawilk\Printing\Api\PrintNode\Util\RequestOptions;
+
+class AccountService extends AbstractService
+{
+    /**
+     * Retrieve all child accounts under the integrator account.
+     *
+     * @param  null|array  $params
+     *                              `limit` => the max number of rows that will be returned - default is 100
+     *                              `dir` => `asc` for ascending, `desc` for descending - default is `desc`
+     *                              `after` => retrieve records with an ID after the provided value
+     * @return Collection<int, Account>
+     */
+    public function all(?array $params = null, null|array|RequestOptions $opts = null): Collection
+    {
+        return $this->requestCollection('get', '/account', $params, opts: $opts, expectedResource: Account::class);
+    }
+
+    /**
+     * Retrieve a specific child account by ID.
+     */
+    public function retrieve(int $id, ?array $params = null, null|array|RequestOptions $opts = null): ?Account
+    {
+        $accounts = $this->requestCollection('get', $this->buildPath('/account/%s', $id), $params, opts: $opts, expectedResource: Account::class);
+
+        return $accounts->first();
+    }
+
+    /**
+     * Create a new child account under the integrator account.
+     *
+     * @param  array  $params
+     *                       `Account[firstname]` => First name (deprecated, use "-" and rely on creatorRef)
+     *                       `Account[lastname]` => Last name (deprecated, use "-" and rely on creatorRef)
+     *                       `Account[email]` => Contact email address (required)
+     *                       `Account[password]` => Password (required, min 8 characters)
+     *                       `Account[creatorRef]` => Your unique reference for this account (recommended)
+     *                       `ApiKeys[]` => Array of API key names to create (max 10, max 16 bytes each)
+     *                       `Tags[]` => Object with tag names as keys and tag values as values (max 1024 bytes per value)
+     */
+    public function create(array $params, null|array|RequestOptions $opts = null): Account
+    {
+        return $this->request('post', '/account', $params, opts: $opts, expectedResource: Account::class);
+    }
+
+    /**
+     * Modify an existing child account.
+     *
+     * @param  int  $id
+     * @param  array  $params
+     *                       `Account[email]` => New email address
+     *                       `Account[password]` => New password (min 8 characters)
+     *                       `Account[creatorRef]` => New creator reference
+     *                       `ApiKeys[]` => Array of API key names to create
+     *                       `Tags[]` => Object with tag names as keys and tag values as values
+     */
+    public function modify(int $id, array $params, null|array|RequestOptions $opts = null): Account
+    {
+        return $this->request('patch', $this->buildPath('/account/%s', $id), $params, opts: $opts, expectedResource: Account::class);
+    }
+
+    /**
+     * Delete a child account. Returns an array of affected IDs.
+     */
+    public function delete(int $id, ?array $params = null, null|array|RequestOptions $opts = null): array
+    {
+        return $this->request('delete', $this->buildPath('/account/%s', $id), $params, opts: $opts);
+    }
+
+    /**
+     * Delete multiple child accounts. Returns an array of affected IDs.
+     *
+     * @param  array  $ids  Array of account IDs to delete
+     */
+    public function deleteMany(array $ids, ?array $params = null, null|array|RequestOptions $opts = null): array
+    {
+        return $this->request('delete', $this->buildPath('/account/%s', ...$ids), $params, opts: $opts);
+    }
+
+    /**
+     * Add credits to a child account.
+     *
+     * @param  int  $id  The account ID
+     * @param  int  $credits  The number of credits to add
+     */
+    public function addCredits(int $id, int $credits, null|array|RequestOptions $opts = null): Account
+    {
+        return $this->request('patch', $this->buildPath('/account/%s', $id), ['Account[credits]' => $credits], opts: $opts, expectedResource: Account::class);
+    }
+
+    /**
+     * Set the state of a child account (e.g. suspend or activate).
+     *
+     * @param  int  $id  The account ID
+     * @param  string  $state  The state to set (e.g. 'active', 'suspended')
+     */
+    public function setState(int $id, string $state, null|array|RequestOptions $opts = null): Account
+    {
+        return $this->request('patch', $this->buildPath('/account/%s', $id), ['Account[state]' => $state], opts: $opts, expectedResource: Account::class);
+    }
+
+    /**
+     * Suspend a child account.
+     */
+    public function suspend(int $id, null|array|RequestOptions $opts = null): Account
+    {
+        return $this->setState($id, 'suspended', $opts);
+    }
+
+    /**
+     * Activate a child account.
+     */
+    public function activate(int $id, null|array|RequestOptions $opts = null): Account
+    {
+        return $this->setState($id, 'active', $opts);
+    }
+
+    /**
+     * Delete a tag from a child account.
+     *
+     * @param  int  $id  The account ID
+     * @param  string  $tagName  The name of the tag to delete
+     */
+    public function deleteTag(int $id, string $tagName, null|array|RequestOptions $opts = null): array
+    {
+        return $this->request('delete', $this->buildPath('/account/%s/tag/%s', $id) . '/' . urlencode($tagName), opts: $opts);
+    }
+
+    /**
+     * Delete an API key from a child account.
+     *
+     * @param  int  $id  The account ID
+     * @param  string  $apiKey  The API key to delete
+     */
+    public function deleteApiKey(int $id, string $apiKey, null|array|RequestOptions $opts = null): array
+    {
+        return $this->request('delete', $this->buildPath('/account/%s/apikey/%s', $id) . '/' . urlencode($apiKey), opts: $opts);
+    }
+}

--- a/src/Api/PrintNode/Service/ServiceFactory.php
+++ b/src/Api/PrintNode/Service/ServiceFactory.php
@@ -13,6 +13,7 @@ use Rawilk\Printing\Api\PrintNode\PrintNodeClientInterface;
  *
  * @internal
  *
+ * @property-read \Rawilk\Printing\Api\PrintNode\Service\AccountService $accounts
  * @property-read \Rawilk\Printing\Api\PrintNode\Service\ComputerService $computers
  * @property-read \Rawilk\Printing\Api\PrintNode\Service\PrinterService $printers
  * @property-read \Rawilk\Printing\Api\PrintNode\Service\PrintJobService $printJobs
@@ -23,6 +24,7 @@ class ServiceFactory
     protected array $services = [];
 
     private static array $classMap = [
+        'accounts' => AccountService::class,
         'computers' => ComputerService::class,
         'printers' => PrinterService::class,
         'printJobs' => PrintJobService::class,

--- a/tests/Feature/Api/PrintNode/Fixtures/responses/account_created.json
+++ b/tests/Feature/Api/PrintNode/Fixtures/responses/account_created.json
@@ -1,0 +1,25 @@
+[
+    {
+        "id": 12347,
+        "firstname": "-",
+        "lastname": "-",
+        "email": "newcustomer@example.com",
+        "creatorEmail": "integrator@example.com",
+        "creatorRef": "customer_789",
+        "createTimestamp": "2024-03-01 09:00:00",
+        "ApiKeys": [
+            {
+                "name": "production",
+                "value": "api_key_new123"
+            }
+        ],
+        "Tags": {
+            "plan": "trial",
+            "source": "api"
+        },
+        "state": "active",
+        "credits": 100,
+        "numComputers": 0,
+        "totalPrints": 0
+    }
+]

--- a/tests/Feature/Api/PrintNode/Fixtures/responses/account_single.json
+++ b/tests/Feature/Api/PrintNode/Fixtures/responses/account_single.json
@@ -1,0 +1,29 @@
+[
+    {
+        "id": 12345,
+        "firstname": "-",
+        "lastname": "-",
+        "email": "customer1@example.com",
+        "creatorEmail": "integrator@example.com",
+        "creatorRef": "customer_123",
+        "createTimestamp": "2024-01-15 10:30:00",
+        "ApiKeys": [
+            {
+                "name": "production",
+                "value": "api_key_abc123"
+            },
+            {
+                "name": "development",
+                "value": "api_key_dev456"
+            }
+        ],
+        "Tags": {
+            "plan": "premium",
+            "region": "us-east"
+        },
+        "state": "active",
+        "credits": 1000,
+        "numComputers": 2,
+        "totalPrints": 150
+    }
+]

--- a/tests/Feature/Api/PrintNode/Fixtures/responses/account_suspended.json
+++ b/tests/Feature/Api/PrintNode/Fixtures/responses/account_suspended.json
@@ -1,0 +1,29 @@
+[
+    {
+        "id": 12345,
+        "firstname": "-",
+        "lastname": "-",
+        "email": "customer1@example.com",
+        "creatorEmail": "integrator@example.com",
+        "creatorRef": "customer_123",
+        "createTimestamp": "2024-01-15 10:30:00",
+        "ApiKeys": [
+            {
+                "name": "production",
+                "value": "api_key_abc123"
+            },
+            {
+                "name": "development",
+                "value": "api_key_dev456"
+            }
+        ],
+        "Tags": {
+            "plan": "premium",
+            "region": "us-east"
+        },
+        "state": "suspended",
+        "credits": 1000,
+        "numComputers": 2,
+        "totalPrints": 150
+    }
+]

--- a/tests/Feature/Api/PrintNode/Fixtures/responses/accounts.json
+++ b/tests/Feature/Api/PrintNode/Fixtures/responses/accounts.json
@@ -1,0 +1,52 @@
+[
+    {
+        "id": 12345,
+        "firstname": "-",
+        "lastname": "-",
+        "email": "customer1@example.com",
+        "creatorEmail": "integrator@example.com",
+        "creatorRef": "customer_123",
+        "createTimestamp": "2024-01-15 10:30:00",
+        "ApiKeys": [
+            {
+                "name": "production",
+                "value": "api_key_abc123"
+            },
+            {
+                "name": "development",
+                "value": "api_key_dev456"
+            }
+        ],
+        "Tags": {
+            "plan": "premium",
+            "region": "us-east"
+        },
+        "state": "active",
+        "credits": 1000,
+        "numComputers": 2,
+        "totalPrints": 150
+    },
+    {
+        "id": 12346,
+        "firstname": "-",
+        "lastname": "-",
+        "email": "customer2@example.com",
+        "creatorEmail": "integrator@example.com",
+        "creatorRef": "customer_456",
+        "createTimestamp": "2024-01-20 14:45:00",
+        "ApiKeys": [
+            {
+                "name": "production",
+                "value": "api_key_xyz789"
+            }
+        ],
+        "Tags": {
+            "plan": "basic",
+            "region": "eu-west"
+        },
+        "state": "active",
+        "credits": 500,
+        "numComputers": 1,
+        "totalPrints": 75
+    }
+]

--- a/tests/Feature/Api/PrintNode/PrintNodeClientTest.php
+++ b/tests/Feature/Api/PrintNode/PrintNodeClientTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rawilk\Printing\Api\PrintNode\PrintNodeClient;
+use Rawilk\Printing\Api\PrintNode\Service\AccountService;
 use Rawilk\Printing\Api\PrintNode\Service\WhoamiService;
 
 beforeEach(function () {
@@ -10,5 +11,6 @@ beforeEach(function () {
 });
 
 it('exposes properties for services', function () {
-    expect($this->client->whoami)->toBeInstanceOf(WhoamiService::class);
+    expect($this->client->whoami)->toBeInstanceOf(WhoamiService::class)
+        ->and($this->client->accounts)->toBeInstanceOf(AccountService::class);
 });

--- a/tests/Feature/Api/PrintNode/Service/AccountServiceTest.php
+++ b/tests/Feature/Api/PrintNode/Service/AccountServiceTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\CarbonInterface;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Http;
+use Rawilk\Printing\Api\PrintNode\PrintNodeClient;
+use Rawilk\Printing\Api\PrintNode\Resources\Account;
+use Rawilk\Printing\Api\PrintNode\Service\AccountService;
+use Rawilk\Printing\Tests\Feature\Api\PrintNode\FakesPrintNodeRequests;
+
+uses(FakesPrintNodeRequests::class);
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+
+    $this->fakeRequests();
+
+    $client = new PrintNodeClient(['api_key' => 'my-key']);
+    $this->service = new AccountService($client);
+});
+
+it('retrieves all child accounts', function () {
+    $this->fakeRequest('accounts');
+
+    $response = $this->service->all();
+
+    expect($response)->toHaveCount(2)
+        ->toContainOnlyInstancesOf(Account::class);
+});
+
+it('can retrieve a specific account', function () {
+    $this->fakeRequest('account_single', expectation: function (Request $request) {
+        expect($request->url())->toEndWith('/account/12345');
+    });
+
+    $account = $this->service->retrieve(12345);
+
+    expect($account)
+        ->not->toBeNull()
+        ->id->toBe(12345)
+        ->email->toBe('customer1@example.com')
+        ->creatorEmail->toBe('integrator@example.com')
+        ->creatorRef->toBe('customer_123')
+        ->state->toBe('active')
+        ->credits->toBe(1000)
+        ->isActive()->toBeTrue()
+        ->isSuspended()->toBeFalse()
+        ->createdAt()->toBeInstanceOf(CarbonInterface::class)
+        ->createdAt()->toBe(Date::parse('2024-01-15 10:30:00'));
+});
+
+it('can create a child account', function () {
+    $this->fakeRequest('account_created', expectation: function (Request $request) {
+        expect($request->method())->toBe('POST')
+            ->and($request->url())->toEndWith('/account')
+            ->and($request->data())->toMatchArray([
+                'Account' => [
+                    'firstname' => '-',
+                    'lastname' => '-',
+                    'email' => 'newcustomer@example.com',
+                    'password' => 'securepass123',
+                    'creatorRef' => 'customer_789',
+                ],
+                'ApiKeys' => ['production'],
+                'Tags' => [
+                    'plan' => 'trial',
+                    'source' => 'api',
+                ],
+            ]);
+    });
+
+    $account = $this->service->create([
+        'Account' => [
+            'firstname' => '-',
+            'lastname' => '-',
+            'email' => 'newcustomer@example.com',
+            'password' => 'securepass123',
+            'creatorRef' => 'customer_789',
+        ],
+        'ApiKeys' => ['production'],
+        'Tags' => [
+            'plan' => 'trial',
+            'source' => 'api',
+        ],
+    ]);
+
+    expect($account)
+        ->toBeInstanceOf(Account::class)
+        ->id->toBe(12347)
+        ->email->toBe('newcustomer@example.com')
+        ->creatorRef->toBe('customer_789')
+        ->state->toBe('active')
+        ->credits->toBe(100);
+});
+
+it('can modify a child account', function () {
+    $this->fakeRequest('account_single', expectation: function (Request $request) {
+        expect($request->method())->toBe('PATCH')
+            ->and($request->url())->toEndWith('/account/12345')
+            ->and($request->data())->toMatchArray([
+                'Account' => [
+                    'email' => 'newemail@example.com',
+                ],
+            ]);
+    });
+
+    $account = $this->service->modify(12345, [
+        'Account' => [
+            'email' => 'newemail@example.com',
+        ],
+    ]);
+
+    expect($account)->toBeInstanceOf(Account::class);
+});
+
+it('can delete a child account', function () {
+    $this->fakeRequest(
+        callback: fn () => [12345],
+        expectation: function (Request $request) {
+            expect($request->method())->toBe('DELETE')
+                ->and($request->url())->toEndWith('/account/12345');
+        },
+    );
+
+    $response = $this->service->delete(12345);
+
+    expect($response)->toBeArray()
+        ->toEqualCanonicalizing([12345]);
+});
+
+it('can delete multiple child accounts', function () {
+    $this->fakeRequest(
+        callback: fn () => [12345, 12346],
+        expectation: function (Request $request) {
+            expect($request->method())->toBe('DELETE')
+                ->and($request->url())->toContain('/account/12345,12346');
+        },
+    );
+
+    $response = $this->service->deleteMany([12345, 12346]);
+
+    expect($response)->toBeArray()
+        ->toEqualCanonicalizing([12345, 12346]);
+});
+
+it('can add credits to a child account', function () {
+    $this->fakeRequest('account_single', expectation: function (Request $request) {
+        expect($request->method())->toBe('PATCH')
+            ->and($request->url())->toEndWith('/account/12345')
+            ->and($request->data())->toMatchArray([
+                'Account[credits]' => 500,
+            ]);
+    });
+
+    $account = $this->service->addCredits(12345, 500);
+
+    expect($account)->toBeInstanceOf(Account::class);
+});
+
+it('can suspend a child account', function () {
+    $this->fakeRequest('account_suspended', expectation: function (Request $request) {
+        expect($request->method())->toBe('PATCH')
+            ->and($request->url())->toEndWith('/account/12345')
+            ->and($request->data())->toMatchArray([
+                'Account[state]' => 'suspended',
+            ]);
+    });
+
+    $account = $this->service->suspend(12345);
+
+    expect($account)
+        ->toBeInstanceOf(Account::class)
+        ->state->toBe('suspended')
+        ->isSuspended()->toBeTrue()
+        ->isActive()->toBeFalse();
+});
+
+it('can activate a child account', function () {
+    $this->fakeRequest('account_single', expectation: function (Request $request) {
+        expect($request->method())->toBe('PATCH')
+            ->and($request->url())->toEndWith('/account/12345')
+            ->and($request->data())->toMatchArray([
+                'Account[state]' => 'active',
+            ]);
+    });
+
+    $account = $this->service->activate(12345);
+
+    expect($account)->toBeInstanceOf(Account::class);
+});
+
+it('can delete a tag from a child account', function () {
+    $this->fakeRequest(
+        callback: fn () => [],
+        expectation: function (Request $request) {
+            expect($request->method())->toBe('DELETE')
+                ->and($request->url())->toContain('/account/12345/tag/plan');
+        },
+    );
+
+    $response = $this->service->deleteTag(12345, 'plan');
+
+    expect($response)->toBeArray();
+});
+
+it('can delete an API key from a child account', function () {
+    $this->fakeRequest(
+        callback: fn () => [],
+        expectation: function (Request $request) {
+            expect($request->method())->toBe('DELETE')
+                ->and($request->url())->toContain('/account/12345/apikey/');
+        },
+    );
+
+    $response = $this->service->deleteApiKey(12345, 'api_key_abc123');
+
+    expect($response)->toBeArray();
+});

--- a/tests/Feature/Api/PrintNode/Service/ServiceFactoryTest.php
+++ b/tests/Feature/Api/PrintNode/Service/ServiceFactoryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rawilk\Printing\Api\PrintNode\PrintNodeClient;
+use Rawilk\Printing\Api\PrintNode\Service\AccountService;
 use Rawilk\Printing\Api\PrintNode\Service\ServiceFactory;
 use Rawilk\Printing\Api\PrintNode\Service\WhoamiService;
 
@@ -12,7 +13,8 @@ beforeEach(function () {
 });
 
 it('exposes properties for services', function () {
-    expect($this->serviceFactory->whoami)->toBeInstanceOf(WhoamiService::class);
+    expect($this->serviceFactory->whoami)->toBeInstanceOf(WhoamiService::class)
+        ->and($this->serviceFactory->accounts)->toBeInstanceOf(AccountService::class);
 });
 
 test('multiple calls return the same instance', function () {


### PR DESCRIPTION
1️⃣ This PR addresses the need for PrintNode Integrator account support, specifically for managing child accounts, as requested by the user.

2️⃣ No, all changes are focused on adding PrintNode Integrator account and child account management.

3️⃣ Yes, a comprehensive test suite is included for the new `AccountService`.

4️⃣ This PR introduces full support for PrintNode Integrator accounts, enabling the management of child accounts. This is vital for applications that need to provision and manage PrintNode access for multiple end-users or customers. It provides a complete API for:
- **CRUD operations** for child accounts.
- **Credit management** for child accounts.
- **State management** (suspend/activate) for child accounts.
- **API key and tag management** for child accounts.

This functionality is essential for integrators building platforms that leverage PrintNode for their clients, allowing them to programmatically control and monitor their customers' PrintNode usage.

5️⃣ Thanks for contributing! 🙌

---
<a href="https://cursor.com/background-agent?bcId=bc-ccea4dc0-bd3a-4b85-b1c1-144fac171862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ccea4dc0-bd3a-4b85-b1c1-144fac171862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

