### PR TITLE
Add integrator and child account support

### DIFF
--- a/src/Api/PrintNode/Util/RequestOptions.php
+++ b/src/Api/PrintNode/Util/RequestOptions.php
@@ -73,6 +73,22 @@ class RequestOptions
                 unset($options['api_base']);
             }
 
+            // Integrator Child Account headers convenience options
+            if (array_key_exists('child_account_id', $options)) {
+                $headers['X-Child-Account-By-Id'] = (string) $options['child_account_id'];
+                unset($options['child_account_id']);
+            }
+
+            if (array_key_exists('child_account_email', $options)) {
+                $headers['X-Child-Account-By-Email'] = (string) $options['child_account_email'];
+                unset($options['child_account_email']);
+            }
+
+            if (array_key_exists('child_account_creator_ref', $options)) {
+                $headers['X-Child-Account-By-CreatorRef'] = (string) $options['child_account_creator_ref'];
+                unset($options['child_account_creator_ref']);
+            }
+
             if ($strict && ! empty($options)) {
                 $message = 'Got unexpected keys in options array: ' . implode(', ', array_keys($options));
 


### PR DESCRIPTION
1️⃣ Yes, this is a direct user request to add support for PrintNode Integrator child accounts.

2️⃣ No, this PR contains a single, related change: adding support for PrintNode child account headers.

3️⃣ Tests are not included in this specific PR, but are planned for a follow-up.

4️⃣ This PR adds support for PrintNode Integrator child account headers within `RequestOptions`. This allows integrators to perform API calls on behalf of their child accounts by specifying the child account's ID, email, or creator reference. This functionality is crucial for managing child accounts as described in the PrintNode API documentation.

The following `RequestOptions` are now mapped to their respective PrintNode headers:
- `child_account_id` → `X-Child-Account-By-Id`
- `child_account_email` → `X-Child-Account-By-Email`
- `child_account_creator_ref` → `X-Child-Account-By-CreatorRef`

5️⃣ Thanks for contributing! 🙌

---
<a href="https://cursor.com/background-agent?bcId=bc-9ad03b7f-933b-4245-910f-ec602a12eaf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ad03b7f-933b-4245-910f-ec602a12eaf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

